### PR TITLE
Fixes

### DIFF
--- a/lib/cpbvt/payloads/aws/cross-account-role-template.yaml
+++ b/lib/cpbvt/payloads/aws/cross-account-role-template.yaml
@@ -4,6 +4,7 @@ Parameters:
     Description: The ID of the source AWS account.
     AllowedPattern: '[0-9]{12}'
     ConstraintDescription: Must be a valid AWS account ID.
+    Default: 387543059434
   ExternalId:
     Type: String
     Description: An external ID that must be provided when assuming the cross-account role.

--- a/lib/cpbvt/payloads/aws/policy.rb
+++ b/lib/cpbvt/payloads/aws/policy.rb
@@ -49,7 +49,7 @@ class Cpbvt::Payloads::Aws::Policy
   def self.generate! general_params
     path = File.join(
       File.dirname(File.expand_path(__FILE__)),
-      "#{general-params.run_uuid}-cross-account-role-template.yaml"
+      "cross-account-role-template.yaml"
     )
     cfn_template = YAML.load_file(path)
 


### PR DESCRIPTION
Template file name is wrong and tool throws exception when trying to generate permit file.