### PR TITLE
Fix Validator for DDB GSI size

### DIFF
--- a/examples/aws_2023/validations/ddb.rb
+++ b/examples/aws_2023/validations/ddb.rb
@@ -52,7 +52,7 @@ Cpbvt::Tester::Runner.describe :ddb do
     assert_not_nil(sk)
 
     assert_json(gsi,'IndexStatus').expects_eq('ACTIVE')
-    assert_json(gsi,'TableSizeBytes').expects_gt(0)
+    assert_json(gsi,'IndexSizeBytes').expects_gt(0)
     assert_json(gsi,'ItemCount').expects_gt(0)
 
     set_pass_message "Found dynamodb table GSI with data in it"


### PR DESCRIPTION
Fix to correctly check the size of the DynamoDB GSI